### PR TITLE
Rely on play.http.forwarded.trustedProxies for X-Forwarded-For header parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,6 @@ __Note: the config format has changed with v2.0.0__
 
 ```
 playguard {
-
-  # the http header to use for the client IP address.
-  # If not set, RequestHeader.remoteAddress will be used
-  clientipheader = "X-Forwarded-For"
-
-
   # required for the global GuardFilter
   filter {
     enabled = true
@@ -239,7 +233,17 @@ playguard {
       }
     }
   }
+
+  # deprecated, see 3.1 below
+  # clientipheader = "X-Client-Ip"
 }
 ```
 
+3.1 Configuring the remote IP address
+-------------------------------------
 
+By default, IP-based rate limits will use `RequestHeaders.remoteAddress` as the address of the client. Depending on [how you have configured Play](https://www.playframework.com/documentation/2.6.x/HTTPServer#Configuring-trusted-proxies) this may be the actual remote address of clients connecting directly, or it may be read from the common `X-Forwarded-For` or `Forwarded` headers that are set by proxies and load balancers.
+
+If you are using a reverse proxy (e.g. [nginx](https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/), HAProxy or an [AWS ELB](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html)) in front of your application, you should take care to configure the [`play.http.forwarded.trustedProxies`](https://www.playframework.com/documentation/2.6.x/HTTPServer#Configuring-trusted-proxies) setting, otherwise all requests will be rate-limited against the IP address of the upstream proxy (definitely not what you want).
+
+Guard also supports a `clientipheader` configuration parameter, which is the name of a header to read to find the client IP address. However, no "trusted proxies" processing is done on this value (it's expected to contain a single IP value), so this cannot be used to safely read `X-Forwarded-For` nor `Forwarded` headers. So, for most cases, this should be left unconfigured.

--- a/module/app/com/digitaltangible/playguard/package.scala
+++ b/module/app/com/digitaltangible/playguard/package.scala
@@ -9,15 +9,6 @@ package object playguard {
     (for {
       configuredHeader <- conf.get[Option[String]]("playguard.clientipheader")
       ip <- request.headers.get(configuredHeader)
-    } yield ip) getOrElse {
-
-      // Consider X-Forwarded-For as most accurate if it exists
-      // Since it is easy to forge an X-Forwarded-For, only consider the last ip added by our proxy as the most accurate
-      // https://en.wikipedia.org/wiki/X-Forwarded-For
-      request.headers.get("X-Forwarded-For").map(_.split(",").last.trim).getOrElse {
-        request.remoteAddress
-      }
-
-    }
+    } yield ip) getOrElse(request.remoteAddress)
   }
 }

--- a/module/test/resources/test.conf
+++ b/module/test/resources/test.conf
@@ -1,9 +1,4 @@
 playguard {
-
-  # the http header to use for the client IP address.
-  # If not set, RequestHeader.remoteAddress will be used
-  clientipheader = "X-Forwarded-For"
-
   filter {
     enabled = true
     global {


### PR DESCRIPTION
Pretty straightforward I think, and I've added a test that we're no longer trusting unvalidated any part of `X-Forwarded-For` when `playguard.clientipheader` isn't configured.

Note that when `playguard.clientipheader` _is_ configured, the existing behaviour is to use the entire value of that header (package.scala, line 11), which is ... problematic for `X-Forwarded-For`. I think that'll only work in the case of e.g. the informal `X-Client-Ip` header (which doesn't usually have an appended "path" of proxies). 

I'd recommend fully deprecating that configuration option in any case (although I've left it alone, and it continues to work as it always did), and definitely never mentioning `clientipheader = "X-Forwarded-For"` specifically.

README updated too. Fixes #4 