### PR TITLE
Improve usability of rejectResponse

### DIFF
--- a/module/app/com/digitaltangible/playguard/RateLimitActionFilter.scala
+++ b/module/app/com/digitaltangible/playguard/RateLimitActionFilter.scala
@@ -123,7 +123,7 @@ class FailureRateLimitFunction[R[_] <: Request[_]](rl: RateLimiter)(
       }
     } else {
       logger.warn(s"${request.method} ${request.uri} rejected, failure rate limit for $key exceeded.")
-      rejectResponse(request).map(Some.apply)
+      rejectResponse(request)
     }
   }
 }


### PR DESCRIPTION
Allow rejectResponse to return `Future[Result]` instead of `Result` to improve usability.