### PR TITLE
Make RateLimiter Serializable

### DIFF
--- a/module/app/com/digitaltangible/playguard/RateLimitActionFilter.scala
+++ b/module/app/com/digitaltangible/playguard/RateLimitActionFilter.scala
@@ -136,9 +136,9 @@ class FailureRateLimitFunction[R[_] <: Request[_]](rl: RateLimiter)(
  * @param logPrefix
  * @param clock
  */
-class RateLimiter(size: Int, rate: Float, logPrefix: String = "", clock: Clock = CurrentTimeClock) {
+class RateLimiter(size: Int, rate: Float, logPrefix: String = "", clock: Clock = CurrentTimeClock) extends Serializable {
 
-  private val logger = Logger(this.getClass)
+  @transient private lazy val logger = Logger(this.getClass)
 
   private lazy val tokenBucketGroup = new TokenBucketGroup(size, rate, clock)
 

--- a/module/app/com/digitaltangible/tokenbucket/Clock.scala
+++ b/module/app/com/digitaltangible/tokenbucket/Clock.scala
@@ -7,6 +7,6 @@ trait Clock {
   def now: Long
 }
 
-object CurrentTimeClock extends Clock {
+object CurrentTimeClock extends Clock with Serializable {
   override def now: Long = System.nanoTime()
 }

--- a/module/app/com/digitaltangible/tokenbucket/TokenBucketGroup.scala
+++ b/module/app/com/digitaltangible/tokenbucket/TokenBucketGroup.scala
@@ -8,7 +8,7 @@ package com.digitaltangible.tokenbucket
  * @param rate  refill rate in tokens per second
  * @param clock for mocking the current time.
  */
-class TokenBucketGroup(size: Long, rate: Double, clock: Clock = CurrentTimeClock) {
+class TokenBucketGroup(size: Long, rate: Double, clock: Clock = CurrentTimeClock) extends Serializable {
 
   private val NanosPerSecond = 1000000000
 

--- a/module/test/com/digitaltangible/playguard/RateLimitActionFilterSpec.scala
+++ b/module/test/com/digitaltangible/playguard/RateLimitActionFilterSpec.scala
@@ -8,6 +8,7 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import scala.concurrent.ExecutionContext
 
@@ -54,6 +55,21 @@ class RateLimitActionFilterSpec extends PlaySpec with GuiceOneAppPerSuite with M
       rateLimiter.check("1") mustBe false
       rateLimiter.consume("2") mustBe 1
       rateLimiter.check("2") mustBe true
+    }
+
+    "serialize MyRateLimiter" in {
+      val limiter = new RateLimiter(1, 2)
+
+      val baos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(baos)
+      oos.writeObject(limiter)
+      oos.close()
+
+      val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+      val limiter2 = ois.readObject.asInstanceOf[RateLimiter]
+      ois.close()
+
+      limiter2.consume("") mustBe 0 //not really interested in the result just that it doesn't throw
     }
   }
 


### PR DESCRIPTION
This changes make the RateLimiter object Serializable.

Added small test to check correct serialization.

Use case:
Each user/ip has a specific rate limit configuration, so we create one RateLimiter object per user which is stored in a local cache.


```
[info] All tests passed.
[info] Passed: Total 28, Failed 0, Errors 0, Passed 28
[success] Total time: 5 s, completed Nov 6, 2018 2:34:40 PM
```